### PR TITLE
Feature/disable orbit hover

### DIFF
--- a/src/3d/Viewport3d.tsx
+++ b/src/3d/Viewport3d.tsx
@@ -1,9 +1,10 @@
-import { OrbitControls, OrbitControlsProps, OrthographicCamera, PerspectiveCamera, Plane } from "@react-three/drei";
+import { OrbitControls as Orbit, OrthographicCamera, PerspectiveCamera, Plane } from "@react-three/drei";
 import { Canvas, Vector3 } from "@react-three/fiber";
 import { button, Leva, useControls } from 'leva';
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ActionCreators } from 'redux-undo';
-import { Camera, GridHelper } from "three";
+import { Camera } from "three";
+import { OrbitControls } from 'three-stdlib';
 import { Grid } from '../Grid/Grid';
 import { getGridCentroid, gridActions } from "../store/grid";
 import { useAppDispatch, useAppSelector } from "../store/hooks";
@@ -84,6 +85,7 @@ const Viewport3d = () => {
 
     const perspectiveCamera = useRef<Camera>(null);
     const orthographicCamera = useRef<Camera>(null);
+    const orbitControls = useRef<OrbitControls>(null);
 
     const zoomExtents = useCallback(() => {
 
@@ -138,7 +140,7 @@ const Viewport3d = () => {
             <Leva hidden={window.location.hash !== '#debug'} />
             <Canvas shadows={true} onKeyDown={handleKeyPress}>
                 <color attach="background" args={[0.9, 0.9, 0.9]} />
-                <OrbitControls target={cameraTarget} />
+                <Orbit target={cameraTarget} ref={orbitControls}/>
                 <PerspectiveCamera makeDefault={isPerspective} position={cameraLocation} fov={75} ref={perspectiveCamera} />
                 <OrthographicCamera makeDefault={!isPerspective} position={cameraLocation} zoom={75} ref={orthographicCamera} />
 
@@ -151,7 +153,7 @@ const Viewport3d = () => {
                     shadow-camera-top={10}
                     shadow-camera-bottom={-10} intensity={0.8} />
 
-                <Grid />
+                <Grid orbitControls={orbitControls}/>
                 <Plane receiveShadow={true} scale={100} rotation-x={-Math.PI * 0.5} position-y={-0.5}>
                     <shadowMaterial opacity={0.1} />
                 </Plane>

--- a/src/Grid/Cell.tsx
+++ b/src/Grid/Cell.tsx
@@ -1,8 +1,9 @@
 import { Edges } from '@react-three/drei';
 import { ThreeEvent } from '@react-three/fiber';
-import { useEffect, useState } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { Euler } from 'three';
+import { OrbitControls } from 'three-stdlib';
 import { gridActions } from '../store/grid';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { CellProps } from '../store/types';
@@ -25,7 +26,7 @@ export enum Direction {
     yNeg = 'yNeg'
 }
 
-export function Cell(props: CellProps) {
+export function Cell(props: CellProps & { orbitControls: RefObject<OrbitControls> }) {
     const dispatch = useAppDispatch();
 
     const mode = useAppSelector(state => state.ui.mode);
@@ -77,7 +78,9 @@ export function Cell(props: CellProps) {
                         blockId={props.blockId}
                         scale={F * 2}
                         position={face.position}
-                        rotation={face.rotation} />
+                        rotation={face.rotation} 
+                        orbitControls={props.orbitControls}
+                        />
                     )
                 })
             }

--- a/src/Grid/Floor.tsx
+++ b/src/Grid/Floor.tsx
@@ -1,8 +1,10 @@
+import { RefObject } from "react";
 import { Euler, Vector3 } from "three";
+import { OrbitControls } from 'three-stdlib';
 import { Direction } from "./Cell";
 import Face from "./Face";
 
-const Floor: React.FC<{ size: [number, number, number] }> = ({ size }) => {
+const Floor: React.FC<{ size: [number, number, number], orbitControls: RefObject<OrbitControls> }> = ({ size, orbitControls }) => {
     return (
         <>
             {Array.from(Array(size[0]), (_, x) => (
@@ -14,6 +16,7 @@ const Floor: React.FC<{ size: [number, number, number] }> = ({ size }) => {
                             scale={1}
                             position={new Vector3(0, 0.5, 0)}
                             rotation={new Euler(-Math.PI / 2, 0, 0)}
+                            orbitControls={orbitControls}
                         />
                     </group>
                 ))

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -1,10 +1,12 @@
+import { RefObject } from 'react';
+import { OrbitControls } from 'three-stdlib';
 import { useAppSelector } from '../store/hooks';
 import { CellProps } from '../store/types';
 import { ActiveTool } from '../store/ui';
 import { Cell } from "./Cell";
 import Floor from './Floor';
 
-export const Grid = () => {
+export const Grid = (props: {orbitControls: RefObject<OrbitControls> }) => {
     const grid = useAppSelector(state => state.grid.present);
     const mode = useAppSelector(state => state.ui.mode);
 
@@ -15,10 +17,11 @@ export const Grid = () => {
                     <Cell
                         {...cell}
                         key={cell.blockId}
+                        orbitControls={props.orbitControls}
                     />
                 ) : null;;
             })}
-            {mode === ActiveTool.Add && <Floor size={grid.size} />}
+            {mode === ActiveTool.Add && <Floor size={grid.size} orbitControls={props.orbitControls} />}
         </>
     );
 }


### PR DESCRIPTION
Disable hover preview when orbiting (#3)

Works by passing a ref of the orbit controls to the faces. The faces subscribe to the orbit start and end.